### PR TITLE
Created the OpenAPI 3.0.0 documentation for the Passport Office API

### DIFF
--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -1,0 +1,282 @@
+openapi: 3.0.0
+info:
+  title: Passport Office API
+  description: Passport Office API providing passport and people managment
+  version: 0.0.1
+servers:
+  - url: localhost:8080/v1
+paths:
+  /persons:
+    get:
+      tags:
+       - person
+      summary: Returns a list of persons
+      description: People managment
+      operationId: getPersons
+      responses:
+        '200':    
+          $ref: '#/components/requestBodies/PersonsBody'
+    post:
+      tags:
+       - person
+      summary: Creates a person
+      description: People managment
+      operationId: createPerson 
+      requestBody:
+        $ref: '#/components/requestBodies/PersonBody'
+      responses:
+        '201':
+          description: A created person
+          content:
+            application/json:
+              schema: 
+                $ref: '#/components/requestBodies/PersonBody'
+  '/persons/{personId}':
+    get:
+      tags:
+       - person
+      parameters:
+        - name: personId
+          in: path
+          description: ID of the person
+          required: true
+          schema:
+            type: integer
+      summary: Returns a person
+      description: People managment
+      operationId: getPerson
+      responses:
+        '200':    
+          $ref: '#/components/requestBodies/PersonBody' 
+    put:
+      tags:
+       - person
+      parameters:
+        - name: personId
+          in: path
+          description: ID of the person
+          required: true
+          schema:
+            type: integer
+      summary: Updates a person
+      description: People managment
+      operationId: putPerson
+      responses:
+        '200':    
+          $ref: '#/components/requestBodies/PersonBody'
+    delete:
+      tags:
+       - person
+      parameters:
+        - name: personId
+          in: path
+          description: ID of the person
+          required: true
+          schema:
+            type: integer
+      summary: Deletes a person.
+      description: People managment.
+      operationId: deletePerson
+      responses:
+        '200':    
+          $ref: '#/components/requestBodies/PersonBody'       
+  '/persons/{personId}/active_passports':
+    get:
+      tags:
+       - person
+      parameters:
+        - name: personId
+          in: path
+          description: ID of the person
+          required: true
+          schema:
+            type: integer
+      summary: Returns a list of active passports of the person
+      description: People managment
+      operationId: getActivePassports
+      responses:
+        '200':    
+          $ref: '#/components/requestBodies/PassportsBody' 
+    post:
+      tags:
+       - person
+      parameters:
+        - name: personId
+          in: path
+          description: ID of the person
+          required: true
+          schema:
+            type: integer
+      summary: Creates an active passport for the person
+      description: People managment
+      operationId: createActivePassport
+      requestBody:
+        $ref: '#/components/requestBodies/PassportBody'
+      responses:
+        '201':
+          description: A created active passport
+          content:
+            application/json:
+              schema: 
+                $ref: '#/components/requestBodies/PassportBody' 
+  '/persons/{personId}/active_passports/{passportNumber}':
+    put:
+      tags:
+       - person
+      parameters:
+        - name: personId
+          in: path
+          description: ID of the person
+          required: true
+          schema:
+            type: integer
+        - name: passportNumber
+          in: path
+          description: ID of the person
+          required: true
+          schema:
+            type: integer      
+      summary: Adds the passport to the active passport of the person
+      description: People managment
+      operationId: putActivePassport
+      responses:
+        '200':    
+          $ref: '#/components/requestBodies/PassportBody'
+  '/persons/{personId}/lost_passports/{passportNumber}': 
+    put:
+      tags:
+       - person
+      parameters:
+        - name: personId
+          in: path
+          description: ID of the person
+          required: true
+          schema:
+            type: integer
+        - name: passportNumber
+          in: path
+          description: ID of the person
+          required: true
+          schema:
+            type: integer      
+      summary: Adds the passport to the lost passports list of the person and deletes it from the active passports
+      description: People managment
+      operationId: putLostPassport
+      responses:
+        '200':    
+          $ref: '#/components/requestBodies/PassportBody'
+  /passports:
+    get:
+      parameters:
+        - in: query
+          name: min_given_date
+          schema:
+            type: string
+          description: The minimum given date of passports
+        - in: query
+          name: max_given_date
+          schema:
+            type: string
+          description: The maximum given date of passports
+      tags:
+       - passport
+      summary: Returns a list of passports
+      description: Passport managment
+      operationId: getPassports
+      responses:
+        '200':    
+          $ref: '#/components/requestBodies/PassportBody'
+    post:
+      tags:
+       - passport
+      summary: Creates a passport
+      description: People managment
+      operationId: createPassport 
+      requestBody:
+        $ref: '#/components/requestBodies/PassportBody'
+      responses:
+        '201':
+          description: A created passport
+          content:
+            application/json:
+              schema: 
+                $ref: '#/components/requestBodies/PassportBody'
+  '/passports/{passportNumber}/persons':
+    get:
+      tags:
+       - passport
+      parameters:
+        - name: passportNumber
+          in: path
+          description: ID of the passport
+          required: true
+          schema:
+            type: integer
+      summary: Returns a person that has the passport
+      description: Passport managment
+      operationId: getPesonByPassport
+      responses:
+        '200':    
+          $ref: '#/components/requestBodies/PersonBody' 
+          
+components:
+  schemas:
+    Person:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        birthday:
+          type: string
+        country:
+          $ref: '#/components/schemas/Country'
+    Passport:
+      type: object
+      properties:
+        number:
+          type: integer
+        givenDate:
+          type: string
+        departmentCode:
+          type: string  
+    Country:
+      type: string
+      enum:
+        - US
+        - RU
+        - UK
+  requestBodies:
+    PersonsBody:
+      description: A JSON array of persons
+      content:
+        application/json:
+          schema: 
+            type: array
+            items: 
+              oneOf:
+                - $ref: '#/components/schemas/Person'
+    PersonBody:
+      description: A JSON object containing person information
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Person'
+    PassportsBody:
+      description: A JSON array of passports
+      content: 
+        application/json: 
+          schema: 
+            type: array
+            items: 
+              oneOf:
+                - $ref: '#/components/schemas/Passport'
+    PassportBody:
+      description: A JSON object containing passport information
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Passport'

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -56,7 +56,8 @@ paths:
           description: ID of the person
           required: true
           schema:
-            type: integer
+            type: string
+            format: uuid
       summary: Returns a person
       description: People managment
       operationId: getPerson
@@ -72,7 +73,8 @@ paths:
           description: ID of the person
           required: true
           schema:
-            type: integer
+            type: string
+            format: uuid
       summary: Updates a person
       description: People managment
       operationId: putPerson
@@ -90,7 +92,8 @@ paths:
           description: ID of the person
           required: true
           schema:
-            type: integer
+            type: string
+            format: uuid
       summary: Deletes a person.
       description: People managment.
       operationId: deletePerson
@@ -107,7 +110,8 @@ paths:
           description: ID of the person
           required: true
           schema:
-            type: integer
+            type: string
+            format: uuid
         - name: state
           in: query
           schema:
@@ -137,7 +141,8 @@ paths:
           description: ID of the person
           required: true
           schema:
-            type: integer
+            type: string
+            format: uuid
       summary: Creates an active passport for the person
       description: People managment
       operationId: createActivePassport
@@ -156,13 +161,14 @@ paths:
           description: ID of the person
           required: true
           schema:
-            type: integer
+            type: string
+            format: uuid
         - name: passportNumber
           in: path
-          description: ID of the person
+          description: ID of the passport
           required: true
           schema:
-            type: integer
+            type: string
       summary: Gets a passport of a person
       description: People managment
       operationId: getPassport
@@ -178,13 +184,14 @@ paths:
           description: ID of the person
           required: true
           schema:
-            type: integer
+            type: string
+            format: uuid
         - name: passportNumber
           in: path
-          description: ID of the person
+          description: ID of the passport
           required: true
           schema:
-            type: integer
+            type: string
       summary: Updates a passport of a person
       description: People managment
       operationId: putPassport
@@ -202,13 +209,14 @@ paths:
           description: ID of the person
           required: true
           schema:
-            type: integer
+            type: string
+            format: uuid
         - name: passportNumber
           in: path
-          description: ID of the person
+          description: ID of the passport
           required: true
           schema:
-            type: integer
+            type: string
       summary: Deletes a passport of a person
       description: People managment
       operationId: deletePassport
@@ -225,13 +233,14 @@ paths:
           description: ID of the person
           required: true
           schema:
-            type: integer
+            type: string
+            format: uuid
         - name: passportNumber
           in: path
-          description: ID of the person
+          description: ID of the passport
           required: true
           schema:
-            type: integer
+            type: string
       summary: Makes a passport lost
       description: People managment
       operationId: lostPassport

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -219,7 +219,7 @@ paths:
       operationId: getPassport
       responses:
         '200':
-          $ref: '#/components/requestBodies/PersonBody'
+          $ref: '#/components/requestBodies/PassportBody'
     delete:
       tags:
         - passport

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -46,6 +46,8 @@ paths:
       responses:
         '201':
           $ref: '#/components/responses/PersonResponse'
+        '400':
+          description: Bad request
   '/persons/{personId}':
     get:
       tags:
@@ -64,6 +66,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/PersonResponse'
+        '404':
+          description: Not found
     put:
       tags:
         - person
@@ -83,6 +87,12 @@ paths:
       responses:
         '200':
           $ref: '#/components/requestBodies/PersonRequest'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+        '409':
+          description: Conflict
     delete:
       tags:
         - person
@@ -99,7 +109,9 @@ paths:
       operationId: deletePerson
       responses:
         '204':
-          description: Person has been deleted
+          description: No content
+        '404':
+          description: Not found
   '/persons/{personId}/passports':
     get:
       tags:
@@ -132,6 +144,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/PassportsResponse'
+        '404':
+          description: Not found
     post:
       tags:
         - person
@@ -151,6 +165,10 @@ paths:
       responses:
         '201':
           $ref: '#/components/responses/PassportsResponse'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
   '/persons/{personId}/passports/{passportNumber}':
     get:
       tags:
@@ -175,6 +193,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/PassportResponse'
+        '404':
+          description: Not found
     put:
       tags:
         - person
@@ -200,6 +220,12 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/PassportResponse'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+        '409':
+          description: Conflict
     delete:
       tags:
         - person
@@ -222,7 +248,9 @@ paths:
       operationId: deletePassport
       responses:
         '204':
-          description: Passport has been deleted
+          description: No content
+        '404':
+          description: Not found
   '/persons/{personId}/passports/{passportNumber}/loss':
     post:
       tags:
@@ -247,6 +275,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/PassportResponse'
+        '404':
+          description: Not found
         '409':
           description: A passport can be lost only once
 components:

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.0.3
 info:
   title: Passport Office API
   description: Passport Office API providing passport and people managment
@@ -10,27 +10,42 @@ paths:
     get:
       tags:
         - person
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+          description: Page number of the results
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            maximum: 100
+            default: 100
+          description: Number of results per page
+        - in: query
+          name: passportNumber
+          schema:
+            type: string
+          description: Returns a person by a passport number
       summary: Returns a list of persons
       description: People managment
       operationId: getPersons
       responses:
         '200':
-          $ref: '#/components/requestBodies/PersonsBody'
+          $ref: '#/components/responses/PersonsResponse'
     post:
       tags:
         - person
-      summary: Creates a person
+      summary: Creates persons
       description: People managment
-      operationId: createPerson
+      operationId: createPersons
       requestBody:
-        $ref: '#/components/requestBodies/PersonBody'
+        $ref: '#/components/requestBodies/PersonsRequest'
       responses:
         '201':
-          description: A created person
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/requestBodies/PersonBody'
+          $ref: '#/components/responses/PersonResponse'
   '/persons/{personId}':
     get:
       tags:
@@ -47,7 +62,7 @@ paths:
       operationId: getPerson
       responses:
         '200':
-          $ref: '#/components/requestBodies/PersonBody'
+          $ref: '#/components/responses/PersonResponse'
     put:
       tags:
         - person
@@ -62,10 +77,10 @@ paths:
       description: People managment
       operationId: putPerson
       requestBody:
-        $ref: '#/components/requestBodies/PersonBody'
+        $ref: '#/components/requestBodies/PersonRequest'
       responses:
         '200':
-          $ref: '#/components/requestBodies/PersonBody'
+          $ref: '#/components/requestBodies/PersonRequest'
     delete:
       tags:
         - person
@@ -80,9 +95,9 @@ paths:
       description: People managment.
       operationId: deletePerson
       responses:
-        '200':
-          $ref: '#/components/requestBodies/PersonBody'
-  '/persons/{personId}/active_passports':
+        '204':
+          description: Person has been deleted
+  '/persons/{personId}/passports':
     get:
       tags:
         - person
@@ -93,12 +108,26 @@ paths:
           required: true
           schema:
             type: integer
-      summary: Returns a list of active passports of the person
+        - name: state
+          in: query
+          schema:
+            $ref: '#/components/schemas/PassportState'
+        - name: minGivenDate
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: maxGivenDate
+          in: query
+          schema:
+            type: string
+            format: date
+      summary: Returns a list of passports of the person
       description: People managment
-      operationId: getActivePassports
+      operationId: getPassports
       responses:
         '200':
-          $ref: '#/components/requestBodies/PassportsBody'
+          $ref: '#/components/responses/PassportsResponse'
     post:
       tags:
         - person
@@ -113,16 +142,12 @@ paths:
       description: People managment
       operationId: createActivePassport
       requestBody:
-        $ref: '#/components/requestBodies/PassportBody'
+        $ref: '#/components/requestBodies/PassportsRequest'
       responses:
         '201':
-          description: A created active passport
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/requestBodies/PassportBody'
-  '/persons/{personId}/active_passports/{passportNumber}':
-    put:
+          $ref: '#/components/responses/PassportsResponse'
+  '/persons/{personId}/passports/{passportNumber}':
+    get:
       tags:
         - person
       parameters:
@@ -138,170 +163,132 @@ paths:
           required: true
           schema:
             type: integer
-      summary: Adds the passport to the active passport of the person
+      summary: Gets a passport of a person
       description: People managment
-      operationId: putActivePassport
-      responses:
-        '200':
-          $ref: '#/components/requestBodies/PassportBody'
-  '/persons/{personId}/lost_passports/{passportNumber}':
-    put:
-      tags:
-        - person
-      parameters:
-        - name: personId
-          in: path
-          description: ID of the person
-          required: true
-          schema:
-            type: integer
-        - name: passportNumber
-          in: path
-          description: ID of the person
-          required: true
-          schema:
-            type: integer
-      summary: Adds the passport to the lost passports list of the person and deletes it from the active passports
-      description: People managment
-      operationId: putLostPassport
-      responses:
-        '200':
-          $ref: '#/components/requestBodies/PassportBody'
-  /passports:
-    get:
-      parameters:
-        - in: query
-          name: min_given_date
-          schema:
-            type: string
-          description: The minimum given date of passports
-        - in: query
-          name: max_given_date
-          schema:
-            type: string
-          description: The maximum given date of passports
-      tags:
-        - passport
-      summary: Returns a list of passports
-      description: Passport managment
-      operationId: getPassports
-      responses:
-        '200':
-          $ref: '#/components/requestBodies/PassportBody'
-    post:
-      tags:
-        - passport
-      summary: Creates a passport
-      description: Passport managment
-      operationId: createPassport
-      requestBody:
-        $ref: '#/components/requestBodies/PassportBody'
-      responses:
-        '201':
-          description: A created passport
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/requestBodies/PassportBody'
-  '/passports/{passportNumber}':
-    get:
-      tags:
-        - passport
-      parameters:
-        - name: passportNumber
-          in: path
-          description: ID of the passport
-          required: true
-          schema:
-            type: integer
-      summary: Returns a passport
-      description: Passport managment
       operationId: getPassport
       responses:
         '200':
-          $ref: '#/components/requestBodies/PassportBody'
-    delete:
-      tags:
-        - passport
-      parameters:
-        - name: passportNumber
-          in: path
-          description: ID of the passport
-          required: true
-          schema:
-            type: integer
-      summary: Deletes a passport.
-      description: Passport managment
-      operationId: deletePassport
-      responses:
-        '200':
-          $ref: '#/components/requestBodies/PassportBody'
+          $ref: '#/components/responses/PassportResponse'
     put:
       tags:
-        - passport
+        - person
       parameters:
-        - name: passportNumber
+        - name: personId
           in: path
-          description: ID of the passport
+          description: ID of the person
           required: true
           schema:
             type: integer
-      summary: Updates a passport
-      description: Passport managment
+        - name: passportNumber
+          in: path
+          description: ID of the person
+          required: true
+          schema:
+            type: integer
+      summary: Updates a passport of a person
+      description: People managment
       operationId: putPassport
       requestBody:
-        $ref: '#/components/requestBodies/PassportBody'
+        $ref: '#/components/requestBodies/PassportRequest'
       responses:
         '200':
-          $ref: '#/components/requestBodies/PassportBody'
-  '/passports/{passportNumber}/persons':
-    get:
+          $ref: '#/components/responses/PassportResponse'
+    delete:
       tags:
-        - passport
+        - person
       parameters:
-        - name: passportNumber
+        - name: personId
           in: path
-          description: ID of the passport
+          description: ID of the person
           required: true
           schema:
             type: integer
-      summary: Returns a person that has the passport
-      description: Passport managment
-      operationId: getPesonByPassport
+        - name: passportNumber
+          in: path
+          description: ID of the person
+          required: true
+          schema:
+            type: integer
+      summary: Deletes a passport of a person
+      description: People managment
+      operationId: deletePassport
+      responses:
+        '204':
+          description: Passport has been deleted
+  '/persons/{personId}/passports/{passportNumber}/loss':
+    post:
+      tags:
+        - person
+      parameters:
+        - name: personId
+          in: path
+          description: ID of the person
+          required: true
+          schema:
+            type: integer
+        - name: passportNumber
+          in: path
+          description: ID of the person
+          required: true
+          schema:
+            type: integer
+      summary: Makes a passport lost
+      description: People managment
+      operationId: lostPassport
       responses:
         '200':
-          $ref: '#/components/requestBodies/PersonBody'
-
+          $ref: '#/components/responses/PassportResponse'
+        '409':
+          description: A passport can be lost only once
 components:
   schemas:
     Person:
       type: object
       properties:
         id:
-          type: integer
+          type: string
+          format: uuid
         name:
           type: string
         birthday:
           type: string
+          format: date
         country:
-          $ref: '#/components/schemas/Country'
+          type: string
+          pattern: "[a-zA-Z]{2}"
+          minLength: 2
+          maxLength: 2
+      required:
+        - name
+        - birthday
+        - country
     Passport:
       type: object
       properties:
         number:
-          type: integer
+          type: string
         givenDate:
           type: string
+          format: date
         departmentCode:
           type: string
-    Country:
+      required:
+        - number
+        - givenDate
+        - departmentCode
+    PassportState:
       type: string
       enum:
-        - US
-        - RU
-        - UK
+        - active
+        - lost
   requestBodies:
-    PersonsBody:
+    PersonRequest:
+      description: A person
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Person'
+    PersonsRequest:
       description: A JSON array of persons
       content:
         application/json:
@@ -309,15 +296,20 @@ components:
             type: array
             items:
               oneOf:
-                - $ref: '#/components/schemas/Person'
-    PersonBody:
-      description: A JSON object containing person information
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Person'
-    PassportsBody:
+                -  type: object
+                   properties:
+                     name:
+                       type: string
+                     birthday:
+                       type: string
+                       format: date
+                     country:
+                       type: string
+                       pattern: "[a-zA-Z]{2}"
+                       minLength: 2
+                       maxLength: 2
+            minItems: 1
+    PassportsRequest:
       description: A JSON array of passports
       content:
         application/json:
@@ -326,10 +318,48 @@ components:
             items:
               oneOf:
                 - $ref: '#/components/schemas/Passport'
-    PassportBody:
-      description: A JSON object containing passport information
-      required: true
+    PassportRequest:
+      description: A passport
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Passport'
+  responses:
+    PersonResponse:
+      description: A person
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Person'
+    PersonsResponse:
+      description: A list of persons
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  oneOf:
+                    - $ref: '#/components/schemas/Person'
+              count:
+                type: integer
+              page:
+                type: integer
+    PassportsResponse:
+      description: A list of passports
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              oneOf:
+                - $ref: '#/components/schemas/Passport'
+    PassportResponse:
+      description: A passport
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Passport'
+

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -192,7 +192,7 @@ paths:
       tags:
         - passport
       summary: Creates a passport
-      description: People managment
+      description: Passport managment
       operationId: createPassport
       requestBody:
         $ref: '#/components/requestBodies/PassportBody'
@@ -203,23 +203,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/requestBodies/PassportBody'
+  '/passports/{passportNumber}':
     delete:
       tags:
         - passport
-      summary: Deletes a person.
+      parameters:
+        - name: passportNumber
+          in: path
+          description: ID of the passport
+          required: true
+          schema:
+            type: integer
+      summary: Deletes a passport.
       description: Passport managment
       operationId: deletePassport
       responses:
         '200':
           $ref: '#/components/requestBodies/PassportBody'
-  '/passports/{passportNumber}':
     put:
       tags:
         - passport
       parameters:
         - name: passportNumber
           in: path
-          description: ID of the person
+          description: ID of the passport
           required: true
           schema:
             type: integer

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -9,19 +9,19 @@ paths:
   /persons:
     get:
       tags:
-       - person
+        - person
       summary: Returns a list of persons
       description: People managment
       operationId: getPersons
       responses:
-        '200':    
+        '200':
           $ref: '#/components/requestBodies/PersonsBody'
     post:
       tags:
-       - person
+        - person
       summary: Creates a person
       description: People managment
-      operationId: createPerson 
+      operationId: createPerson
       requestBody:
         $ref: '#/components/requestBodies/PersonBody'
       responses:
@@ -29,12 +29,12 @@ paths:
           description: A created person
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/requestBodies/PersonBody'
   '/persons/{personId}':
     get:
       tags:
-       - person
+        - person
       parameters:
         - name: personId
           in: path
@@ -46,11 +46,11 @@ paths:
       description: People managment
       operationId: getPerson
       responses:
-        '200':    
-          $ref: '#/components/requestBodies/PersonBody' 
+        '200':
+          $ref: '#/components/requestBodies/PersonBody'
     put:
       tags:
-       - person
+        - person
       parameters:
         - name: personId
           in: path
@@ -61,12 +61,14 @@ paths:
       summary: Updates a person
       description: People managment
       operationId: putPerson
+      requestBody:
+        $ref: '#/components/requestBodies/PersonBody'
       responses:
-        '200':    
+        '200':
           $ref: '#/components/requestBodies/PersonBody'
     delete:
       tags:
-       - person
+        - person
       parameters:
         - name: personId
           in: path
@@ -78,12 +80,12 @@ paths:
       description: People managment.
       operationId: deletePerson
       responses:
-        '200':    
-          $ref: '#/components/requestBodies/PersonBody'       
+        '200':
+          $ref: '#/components/requestBodies/PersonBody'
   '/persons/{personId}/active_passports':
     get:
       tags:
-       - person
+        - person
       parameters:
         - name: personId
           in: path
@@ -95,11 +97,11 @@ paths:
       description: People managment
       operationId: getActivePassports
       responses:
-        '200':    
-          $ref: '#/components/requestBodies/PassportsBody' 
+        '200':
+          $ref: '#/components/requestBodies/PassportsBody'
     post:
       tags:
-       - person
+        - person
       parameters:
         - name: personId
           in: path
@@ -117,12 +119,12 @@ paths:
           description: A created active passport
           content:
             application/json:
-              schema: 
-                $ref: '#/components/requestBodies/PassportBody' 
+              schema:
+                $ref: '#/components/requestBodies/PassportBody'
   '/persons/{personId}/active_passports/{passportNumber}':
     put:
       tags:
-       - person
+        - person
       parameters:
         - name: personId
           in: path
@@ -135,17 +137,17 @@ paths:
           description: ID of the person
           required: true
           schema:
-            type: integer      
+            type: integer
       summary: Adds the passport to the active passport of the person
       description: People managment
       operationId: putActivePassport
       responses:
-        '200':    
+        '200':
           $ref: '#/components/requestBodies/PassportBody'
-  '/persons/{personId}/lost_passports/{passportNumber}': 
+  '/persons/{personId}/lost_passports/{passportNumber}':
     put:
       tags:
-       - person
+        - person
       parameters:
         - name: personId
           in: path
@@ -158,12 +160,12 @@ paths:
           description: ID of the person
           required: true
           schema:
-            type: integer      
+            type: integer
       summary: Adds the passport to the lost passports list of the person and deletes it from the active passports
       description: People managment
       operationId: putLostPassport
       responses:
-        '200':    
+        '200':
           $ref: '#/components/requestBodies/PassportBody'
   /passports:
     get:
@@ -179,19 +181,19 @@ paths:
             type: string
           description: The maximum given date of passports
       tags:
-       - passport
+        - passport
       summary: Returns a list of passports
       description: Passport managment
       operationId: getPassports
       responses:
-        '200':    
+        '200':
           $ref: '#/components/requestBodies/PassportBody'
     post:
       tags:
-       - passport
+        - passport
       summary: Creates a passport
       description: People managment
-      operationId: createPassport 
+      operationId: createPassport
       requestBody:
         $ref: '#/components/requestBodies/PassportBody'
       responses:
@@ -199,12 +201,40 @@ paths:
           description: A created passport
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/requestBodies/PassportBody'
+    delete:
+      tags:
+        - passport
+      summary: Deletes a person.
+      description: Passport managment
+      operationId: deletePassport
+      responses:
+        '200':
+          $ref: '#/components/requestBodies/PassportBody'
+  '/passports/{passportNumber}':
+    put:
+      tags:
+        - passport
+      parameters:
+        - name: passportNumber
+          in: path
+          description: ID of the person
+          required: true
+          schema:
+            type: integer
+      summary: Updates a passport
+      description: Passport managment
+      operationId: putPassport
+      requestBody:
+        $ref: '#/components/requestBodies/PassportBody'
+      responses:
+        '200':
+          $ref: '#/components/requestBodies/PassportBody'
   '/passports/{passportNumber}/persons':
     get:
       tags:
-       - passport
+        - passport
       parameters:
         - name: passportNumber
           in: path
@@ -216,9 +246,9 @@ paths:
       description: Passport managment
       operationId: getPesonByPassport
       responses:
-        '200':    
-          $ref: '#/components/requestBodies/PersonBody' 
-          
+        '200':
+          $ref: '#/components/requestBodies/PersonBody'
+
 components:
   schemas:
     Person:
@@ -240,7 +270,7 @@ components:
         givenDate:
           type: string
         departmentCode:
-          type: string  
+          type: string
     Country:
       type: string
       enum:
@@ -252,9 +282,9 @@ components:
       description: A JSON array of persons
       content:
         application/json:
-          schema: 
+          schema:
             type: array
-            items: 
+            items:
               oneOf:
                 - $ref: '#/components/schemas/Person'
     PersonBody:
@@ -266,11 +296,11 @@ components:
             $ref: '#/components/schemas/Person'
     PassportsBody:
       description: A JSON array of passports
-      content: 
-        application/json: 
-          schema: 
+      content:
+        application/json:
+          schema:
             type: array
-            items: 
+            items:
               oneOf:
                 - $ref: '#/components/schemas/Passport'
     PassportBody:

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -204,6 +204,22 @@ paths:
               schema:
                 $ref: '#/components/requestBodies/PassportBody'
   '/passports/{passportNumber}':
+    get:
+      tags:
+        - passport
+      parameters:
+        - name: passportNumber
+          in: path
+          description: ID of the passport
+          required: true
+          schema:
+            type: integer
+      summary: Returns a passport
+      description: Passport managment
+      operationId: getPassport
+      responses:
+        '200':
+          $ref: '#/components/requestBodies/PersonBody'
     delete:
       tags:
         - passport

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -48,6 +48,10 @@ paths:
           $ref: '#/components/responses/PersonResponse'
         '400':
           description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   '/persons/{personId}':
     get:
       tags:
@@ -68,6 +72,10 @@ paths:
           $ref: '#/components/responses/PersonResponse'
         '404':
           description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     put:
       tags:
         - person
@@ -89,10 +97,22 @@ paths:
           $ref: '#/components/requestBodies/PersonRequest'
         '400':
           description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '409':
           description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     delete:
       tags:
         - person
@@ -112,6 +132,10 @@ paths:
           description: No content
         '404':
           description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   '/persons/{personId}/passports':
     get:
       tags:
@@ -146,6 +170,10 @@ paths:
           $ref: '#/components/responses/PassportsResponse'
         '404':
           description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     post:
       tags:
         - person
@@ -167,8 +195,16 @@ paths:
           $ref: '#/components/responses/PassportsResponse'
         '400':
           description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   '/persons/{personId}/passports/{passportNumber}':
     get:
       tags:
@@ -195,6 +231,10 @@ paths:
           $ref: '#/components/responses/PassportResponse'
         '404':
           description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     put:
       tags:
         - person
@@ -222,10 +262,22 @@ paths:
           $ref: '#/components/responses/PassportResponse'
         '400':
           description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '409':
           description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     delete:
       tags:
         - person
@@ -251,6 +303,10 @@ paths:
           description: No content
         '404':
           description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   '/persons/{personId}/passports/{passportNumber}/loss':
     post:
       tags:
@@ -320,6 +376,13 @@ components:
       enum:
         - active
         - lost
+    Error:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: string
   requestBodies:
     PersonRequest:
       description: A person


### PR DESCRIPTION
**Described the following features:**

- people management (name, birthday, birth country) 
- passport management (number, given date, given department code). _Number_ is used as ID of the passport.
- lost passport handling, a person has lost his passport and wants to get a new one 
- get current active passports of a person 
- search a person by passport number 
- search passports by given dates range 

**How to handle passport losing:**

1. Send a PUT request to the _/persons/{personId}/lost_passports/{passportNumber}_ path with the lost passport number. This will move the active passport with the provided number to the lost passports.
2. Send a request with the new passport to the _/persons/{personId}/active_passports_ path. Or create a new passport via /passports and then add this passport to the active passport of the person using a PUT request to _​/persons​/{personId}​/active_passports​/{passportNumber}_.

**Notes:**

- Request Validation has not yet been described.
- It is possible to use the swagger editor: https://editor.swagger.io/ for reviewing this file.